### PR TITLE
build: push to DockerHub and GHCR

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,47 @@
+name: build and push
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@master
+      - name: Login to DockerHub
+        uses: docker/login-action@master
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@master
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@master
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/386
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USER }}/nitter-rss-proxy:latest
+            ghcr.io/${{ github.repository_owner }}/nitter-rss-proxy:latest
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@main
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+          repository: ${{ secrets.DOCKERHUB_USER }}/nitter-rss-proxy
+          short-description: "HTTP server that proxies Twitter RSS feeds served by Nitter"
+          readme-filepath: README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:alpine as builder
+FROM golang:1.20-alpine3.17 as builder
 WORKDIR /build
 COPY . .
-RUN go build -o /nitter-rss-proxy
+RUN apk add --no-cache upx && \
+    go build -ldflags="-s -w" -o /nitter-rss-proxy && \
+    upx --lzma /nitter-rss-proxy
 
-FROM alpine
+FROM alpine:3.17
 LABEL maintainer="github.com/derat/nitter-rss-proxy"
 EXPOSE 8080/tcp
 COPY --from=builder /nitter-rss-proxy /nitter-rss-proxy
-RUN chmod +x /nitter-rss-proxy
-ENTRYPOINT ["/nitter-rss-proxy","-addr","0.0.0.0:8080"]
+ENTRYPOINT [ "/nitter-rss-proxy" ]
+CMD ["-addr", "0.0.0.0:8080"]


### PR DESCRIPTION
Automatically build and push multi-arch docker images to DockerHub and GHCR.
Currently the following platforms are supported:

- linux/amd64
- linux/arm64
- linux/armv7
- linux/armv6
- linux/386

Images can be found at:

- DockerHub: https://hub.docker.com/r/zydou/nitter-rss-proxy
- GHCR: https://github.com/zydou/nitter-rss-proxy/pkgs/container/nitter-rss-proxy

Build logs at: https://github.com/zydou/nitter-rss-proxy/actions/runs/4310581639/jobs/7520121528